### PR TITLE
connection between users and witnesses

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -13,4 +13,8 @@ class PagesController < ApplicationController
   def dashboard
     @mypromises = current_user.promises
   end
+
+  def friends
+   @witness = Witness.link_wt_promise(current_user)
+  end
 end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -13,8 +13,4 @@ class PagesController < ApplicationController
   def dashboard
     @mypromises = current_user.promises
   end
-
-  def friends
-   @witness = Witness.link_wt_promise(current_user)
-  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,7 +1,7 @@
 class User < ApplicationRecord
   has_many :promises, dependent: :destroy
 
-
+  has_many :witnesses
   devise :database_authenticatable, :registerable,
   :recoverable, :rememberable, :trackable, :validatable
 

--- a/app/models/witness.rb
+++ b/app/models/witness.rb
@@ -1,4 +1,9 @@
 class Witness < ApplicationRecord
   belongs_to :promise
   belongs_to :user
+
+  def self.link_wt_promise(witness)
+    joins(:promise).where(promise: { witness: witness })
+  end
 end
+

--- a/app/models/witness.rb
+++ b/app/models/witness.rb
@@ -1,9 +1,5 @@
 class Witness < ApplicationRecord
   belongs_to :promise
   belongs_to :user
-
-  def self.link_wt_promise(witness)
-    joins(:promise).where(promise: { witness: witness })
-  end
 end
 

--- a/app/views/pages/friends.html.erb
+++ b/app/views/pages/friends.html.erb
@@ -1,1 +1,6 @@
 <h1>Hello Friends</h1>
+
+
+<%current_user.witnesses.each do |wit| %>
+ <%= wit.promise.title %>
+<% end %>

--- a/app/views/pages/friends.html.erb
+++ b/app/views/pages/friends.html.erb
@@ -3,4 +3,5 @@
 
 <%current_user.witnesses.each do |wit| %>
  <%= wit.promise.title %>
+ <p>By </p> <%= wit.promise.user.name %>
 <% end %>

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -51,6 +51,7 @@ ActiveRecord::Schema.define(version: 20180404074233) do
     t.inet "last_sign_in_ip"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "avatar", default: "None"
     t.string "provider"
     t.string "uid"
     t.string "facebook_picture_url"
@@ -58,7 +59,6 @@ ActiveRecord::Schema.define(version: 20180404074233) do
     t.string "last_name"
     t.string "token"
     t.datetime "token_expiry"
-    t.string "avatar", default: "None"
     t.string "name"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true

--- a/test/models/bridge_test.rb
+++ b/test/models/bridge_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class BridgeTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
- Added to the User model: has_many :witnesses, because a user can be a witness multiple times. In each time, we want to see the promise for the friends page (thanks George)